### PR TITLE
Fix dereferencing None when no xvfb-options given.

### DIFF
--- a/nosexvfb/__init__.py
+++ b/nosexvfb/__init__.py
@@ -1,1 +1,1 @@
-from xvfb import Xvfb
+from .xvfb import Xvfb

--- a/nosexvfb/xvfb.py
+++ b/nosexvfb/xvfb.py
@@ -23,12 +23,13 @@ class Xvfb(Plugin):
     def configure(self, options, noseconfig):
         super(Xvfb, self).configure(options, noseconfig)
         self.xvfb_options = {}
-        opts = [x.strip() for x in options.xvfb_options.split(",")]
-        for item in opts:
-            key, sign, value = item.partition("=")
-            if not value:
-                value = ''
-            self.xvfb_options[key] = value
+        if options.xvfb_options:
+            opts = [x.strip() for x in options.xvfb_options.split(",")]
+            for item in opts:
+                key, sign, value = item.partition("=")
+                if not value:
+                    value = ''
+                self.xvfb_options[key] = value
 
     def begin(self):
         logger.info('Starting xvfb virtual display 1024x768 with %s' % self.xvfb_options)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup, find_packages
 
-requires = ['nose', 'xvfbwrapper<=0.2.2']
+requires = ['nose', 'xvfbwrapper==0.2.9']
 
 setup(
     name='nose-xvfb',

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ requires = ['nose', 'xvfbwrapper<=0.2.2']
 setup(
     name='nose-xvfb',
     description='Virtual display nose plugin through Xvfb',
-    version='0.12',
+    version='0.13',
     classifiers=[
         "Programming Language :: Python",
         "Topic :: Software Development :: Testing",


### PR DESCRIPTION
Running the tests without any xvfb-options was throwing.  This patch should fix it.

```
File "/usr/lib/python2.7/site-packages/nosexvfb/xvfb.py", line 26, in configure
    opts = [x.strip() for x in options.xvfb_options.split(",") if options.xvfb_options]
AttributeError: 'NoneType' object has no attribute 'split'
```
